### PR TITLE
Added sortOrder to Slookup function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.graylog.plugins</groupId>
     <artifactId>graylog-plugin-slookup-function</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>


### PR DESCRIPTION
As mentioned in #1, added sortOrder to Slookup function. Can now return the requested field on the most recent or older record in relative timeframe. Useful if multiple records that might contain a different value is returned.